### PR TITLE
chore: Use explicit attach_type to create tracing link

### DIFF
--- a/internal/vista/tracing.go
+++ b/internal/vista/tracing.go
@@ -143,7 +143,8 @@ func (t *tracing) traceProg(options *TracingOptions, prog *ebpf.Program, fentryN
 
 	if !options.Pcap || slices.Contains(options.PcapModes, pcapModeEntry) {
 		tracing, err := link.AttachTracing(link.TracingOptions{
-			Program: coll.Programs[fentryName],
+			Program:    coll.Programs[fentryName],
+			AttachType: ebpf.AttachTraceFEntry,
 		})
 		if err != nil {
 			return fmt.Errorf("failed to attach tracing: %w", err)
@@ -154,7 +155,8 @@ func (t *tracing) traceProg(options *TracingOptions, prog *ebpf.Program, fentryN
 
 	if options.Pcap && slices.Contains(options.PcapModes, pcapModeExit) {
 		tracing, err := link.AttachTracing(link.TracingOptions{
-			Program: coll.Programs[fexitName],
+			Program:    coll.Programs[fexitName],
+			AttachType: ebpf.AttachTraceFExit,
 		})
 		if err != nil {
 			return fmt.Errorf("failed to attach tracing: %w", err)


### PR DESCRIPTION
It's for strace to trace BPF syscall, like:

```bash
$ sudo /root/strace/src/strace --trace=bpf -f ./vista --filter-trace-xdp --filter-trace-tc --output-meta --output-tuple --output-limit-lines 4 --pcap-file vista.pcapng icmp
[pid 3742661] bpf(BPF_LINK_CREATE, {link_create={prog_fd=40, target_fd=0, attach_type=BPF_TRACE_FENTRY, flags=0, tracing={}}}, 64) = 31
[pid 3742661] bpf(BPF_LINK_CREATE, {link_create={prog_fd=38, target_fd=0, attach_type=BPF_TRACE_FEXIT, flags=0, tracing={}}}, 64) = 41
[pid 3742655] bpf(BPF_LINK_CREATE, {link_create={prog_fd=39, target_fd=0, attach_type=BPF_TRACE_FENTRY, flags=0, tracing={}}}, 64) = 22
[pid 3742655] bpf(BPF_LINK_CREATE, {link_create={prog_fd=21, target_fd=0, attach_type=BPF_TRACE_FEXIT, flags=0, tracing={}}}, 64) = 23
[pid 3742655] bpf(BPF_LINK_CREATE, {link_create={prog_fd=30, target_fd=0, attach_type=BPF_TRACE_FENTRY, flags=0, tracing={}}}, 64) = 29
[pid 3742655] bpf(BPF_LINK_CREATE, {link_create={prog_fd=32, target_fd=0, attach_type=BPF_TRACE_FEXIT, flags=0, tracing={}}}, 64) = 33
```